### PR TITLE
Add OCR web application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# OCR Web App
+
+This repository provides a simple Flask application that lets you upload an image, preview it, and extract text using Tesseract OCR. The extracted text can be copied to your clipboard from the browser.
+
+## Requirements
+
+- Python 3
+- Flask
+- Pillow
+- pytesseract
+- Tesseract OCR installed on your system
+
+Because this environment is offline, the required packages are not included. Install them using pip and ensure that the `tesseract` binary is available on your PATH.
+
+```
+pip install Flask Pillow pytesseract
+```
+
+## Running the Application
+
+1. Install the dependencies listed above.
+2. Run the application:
+
+```
+python app.py
+```
+
+3. Open `http://localhost:5000` in your browser.
+4. Upload an image, preview it, and click **Extract** to display the text. Use the **Copy** button to copy the text to your clipboard.
+
+## Note
+
+If you wish to use an external OCR service (such as Azure Cognitive Services), replace the call to `pytesseract.image_to_string` in `app.py` with your API call of choice.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,28 @@
+from flask import Flask, render_template, request, redirect, url_for
+from werkzeug.utils import secure_filename
+import os
+import pytesseract
+from PIL import Image
+
+app = Flask(__name__)
+app.config['UPLOAD_FOLDER'] = 'uploads'
+os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        file = request.files.get('image')
+        if file:
+            filename = secure_filename(file.filename)
+            filepath = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+            file.save(filepath)
+            text = pytesseract.image_to_string(Image.open(filepath))
+            return render_template('index.html', image_url=url_for('uploaded_file', filename=filename), text=text)
+    return render_template('index.html')
+
+@app.route('/uploads/<filename>')
+def uploaded_file(filename):
+    return redirect(url_for('static', filename='uploads/' + filename), code=301)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>OCR App</title>
+    <style>
+    img { max-width: 300px; display: block; margin-bottom: 10px; }
+    textarea { width: 100%; height: 200px; }
+    </style>
+</head>
+<body>
+    <h1>OCR App</h1>
+    <form method="POST" enctype="multipart/form-data">
+        <input type="file" name="image" accept="image/*" onchange="previewImage(event)">
+        <button type="submit">Extract</button>
+    </form>
+    <div id="preview"></div>
+    {% if text %}
+    <h2>Extracted Text</h2>
+    <textarea id="output" readonly>{{ text }}</textarea>
+    <button onclick="copyText()">Copy</button>
+    {% endif %}
+<script>
+function previewImage(event) {
+    var output = document.getElementById('preview');
+    output.innerHTML = '';
+    var img = document.createElement('img');
+    img.src = URL.createObjectURL(event.target.files[0]);
+    output.appendChild(img);
+}
+function copyText() {
+    var text = document.getElementById('output');
+    text.select();
+    document.execCommand('copy');
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create simple Flask app `app.py` to upload and OCR images
- add HTML template to preview images and copy extracted text
- document usage and dependencies in `README.md`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687ee30da8d0832c8d2986b7e04c31bf